### PR TITLE
[fix-warn]: For rust-toolchain 1.67.

### DIFF
--- a/rtt_rs2/src/lib.rs
+++ b/rtt_rs2/src/lib.rs
@@ -8,8 +8,6 @@
 #![cfg_attr(not(feature = "host_test"), no_std)]
 #![feature(alloc_error_handler)]
 #![feature(allow_internal_unstable)]
-#![feature(const_fn_fn_ptr_basics)]
-#![feature(const_fn_trait_bound)]
 #![feature(linkage)]
 #![feature(core_intrinsics)]
 #![allow(dead_code)]

--- a/rtt_rs2/src/mutex.rs
+++ b/rtt_rs2/src/mutex.rs
@@ -34,8 +34,8 @@ use core::sync::atomic::*;
 
 const RT_WAITING_FOREVER: isize = -1;
 
-unsafe impl<T: Send> Send for Mutex<T> {}
-unsafe impl<T: Send> Sync for Mutex<T> {}
+unsafe impl<T: Send, M: RawMutexOps + Sized> Send for Mutex<T, M> {}
+unsafe impl<T: Send, M: RawMutexOps + Sized> Sync for Mutex<T, M> {}
 
 pub struct Mutex<T: ?Sized, M = SleepMutex>
 where


### PR DESCRIPTION
1. Remove stable feature.
2. Fix auto-impl `Send` bug.