### PR TITLE
fix the argument of PrebuildRust function in Sconscript

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -25,7 +25,7 @@ else:
   if GetDepend("RT_USING_SMP"):
     SeleceFeature("smp")
 
-  ret = PrebuildRust(cwd, rtconfig.CPU, Rtt_Root, Rtt_Root+"/../applications/")
+  ret = PrebuildRust(cwd, rtconfig.CPU, Rtt_Root, cwd+"/../../applications/")
   if ret == "OK":
     LINKFLAGS = " -L%s" % (cwd + "/rust_out/")
     LINKFLAGS += " -Wl,--whole-archive -lrust -Wl,--no-whole-archive"


### PR DESCRIPTION
在 RT-Thread/rt-thread 中使用 menuconfig 对 rtt_rust 进行拉取后出现编译错误

![image](https://github.com/rust-for-rtthread/rtt_rust/assets/98676202/58c2d535-8efe-46d2-ad7b-73c54c1265a8)

发现是文件路径有问题，所以进行了修改，将 Sconscript 中的 PrebuildRust 函数最后一个参数由 `RTT_Root + "/../applications"` 修改为 `cwd + "/../applications"`